### PR TITLE
feat: adds breakline to mapped description of the import modal

### DIFF
--- a/src/CSVNotice/index.tsx
+++ b/src/CSVNotice/index.tsx
@@ -20,9 +20,14 @@ type CSVNoticeProps = {
 
 const CSVNoticeItem: React.FC<Item> = ({ header, values, description }) => (
   <Space align="start" className={`${styles.item} wand-csv-notice-item`} key={header}>
-    <code>{header}</code>
+    {header !== '' && <code>{header}</code>}
     <div>
-      {description}
+      {description.split('\n').map((line, index) => (
+        <React.Fragment key={index}>
+          {line}
+          <br />
+        </React.Fragment>
+      ))}
       {values && values.length > 0 && (
         <ul>
           {values.map(({ value, description }) => (


### PR DESCRIPTION
- Possibilité de break line dans la description d'un header
- Si la valeur d'un header est vide, on n'affiche plus de balise code
- Répond à un besoin où je dois écrire des règles d'import dans la modal :

Exemple Icare :

{ header: '',
  description: "Rules:\n - All existing data from Homologa source will be destroyed if the imports is successful.\n - If the contaminant does not exist, it will be created, and its group will be "Pesticide" }